### PR TITLE
Option to skip matriculation-number input

### DIFF
--- a/src/spz/spz/static/css/spz.css
+++ b/src/spz/spz/static/css/spz.css
@@ -247,6 +247,16 @@ body {
     width: 100%;
 }
 
+.skip_label {
+    position: absolute;
+    right: 0;
+    padding: .67861429em;
+}
+
+.skip_label > input[type="checkbox"] {
+    vertical-align: baseline !important;
+}
+
 a > strong:only-child {
     display: inline-block;
 }

--- a/src/spz/spz/static/js/spz.js
+++ b/src/spz/spz/static/js/spz.js
@@ -41,6 +41,17 @@ $(document).ready(function(){
             $('input', form).garlic('destroy');
         }, 10);
     });
+
+    $('.skip_label').on('change', function() {
+        var checked = $(this).find('input').is(':checked');
+        var mainInput = $(this).closest('div.labeled.input').find('input').first();
+        mainInput.attr('disabled', checked);
+        if (checked) {
+            mainInput.val($(this).text().trim());
+        } else {
+            mainInput.val('');
+        }
+    });
 });
 
 // contributors welcome :)

--- a/src/spz/spz/static/js/spz.js
+++ b/src/spz/spz/static/js/spz.js
@@ -45,7 +45,7 @@ $(document).ready(function(){
     $('.skip_label').on('change', function() {
         var checked = $(this).find('input').is(':checked');
         var mainInput = $(this).closest('div.labeled.input').find('input').first();
-        mainInput.attr('disabled', checked);
+        mainInput.attr('readonly', checked);
         if (checked) {
             mainInput.val($(this).text().trim());
         } else {

--- a/src/spz/spz/templates/formhelpers.html
+++ b/src/spz/spz/templates/formhelpers.html
@@ -2,7 +2,7 @@
 {# Independent short macros, to allow for greater flexibility #}
 
 
-{% macro render_input(field, width=12, placeholder=None, required=True, required_extras=None, type="text", help=None, icon=None, step=None, min=None, max=None) %}
+{% macro render_input(field, width=12, placeholder=None, required=True, skip=False, required_extras=None, type="text", help=None, icon=None, step=None, min=None, max=None) %}
 <div class="{% if required %}required {% endif %}field{% if field.errors %} error{% endif %}">
     <div class="ui labeled input">
         <div class="ui label" for="{{ field.id }}">
@@ -10,6 +10,9 @@
             {{ field.label }}
         </div>
         <input type="{{ type }}" id="{{ field.id }}" name="{{ field.id }}"{% if field.data != None %} value="{{ field.data }}" {% endif %} placeholder="{{ placeholder|default('', true) }}"{% if required %} data-required="true"{% endif %}{% if step %} step="{{ step }}"{% endif %}{% if min %} min="{{ min }}"{% endif %}{% if max %} max="{{ max }}"{% endif %}{{ (' ' ~ required_extras|safe) if required_extras }} />
+        {% if skip %}
+        <label class="skip_label">{{ skip }} <input type="checkbox" name="{{ field.id }}_skipped"></input></label>
+        {% endif %}
     </div>
     {% for error in field.errors %}
         <span class="ui red pointing prompt label transition visible">{{ error }}</span>

--- a/src/spz/spz/templates/signup.html
+++ b/src/spz/spz/templates/signup.html
@@ -25,7 +25,7 @@ Anmeldung {{ config['SEMESTER_NAME'] }}
             </div>
             <div class="grouped fields">
                 {{ render_option(form.origin, icon='leaf') }}
-                {{ render_input(form.tag, required=False, help='Falls Sie kein KIT-Studierender sind und einen Englischkurs belegen wollen, tragen Sie hier die Ihnen vom Sprachenzentrum erteilte ID ein. Mitarbeiter müssen Ihren KIT-Account (login) eintragen.', icon='barcode') }}
+                {{ render_input(form.tag, skip='Wird nachgereicht', help='Falls Sie kein KIT-Studierender sind und einen Englischkurs belegen wollen, tragen Sie hier die Ihnen vom Sprachenzentrum erteilte ID ein. Mitarbeiter müssen Ihren KIT-Account (login) eintragen.', icon='barcode') }}
             </div>
             <div class="kit-only">
                 <h3 class="ui dividing header">Angaben für Studierende des KIT</h3>

--- a/src/spz/test/test_signup.py
+++ b/src/spz/test/test_signup.py
@@ -107,3 +107,23 @@ def test_doppelganger_signup(client, applicant_data, other_applicant_data, cours
     other_applicant_data['confirm_mail'] = applicant_data['confirm_mail']
 
     test_opened_signup(client, other_applicant_data, other_course)
+
+
+def test_tag_skip(client, applicant_data, course):
+    signup_set_open(course, open=True)
+
+    assert not in_course(applicant_data, course)
+
+    applicant_data.tag = ''
+    data = dict(applicant_data, course=course.id)
+    response = client.post('/', data=data)
+    response_text = get_text(response)
+    assert "Matrikelnummer muss angegeben werden" in response_text
+    assert not in_course(applicant_data, course)
+
+    applicant_data.tag = "Wird nachgereicht"
+    data = dict(applicant_data, course=course.id)
+    response = client.post('/', data=data)
+    response_text = get_text(response)
+    assert "Ihre Registrierung war erfolgreich" in response_text
+    assert in_course(applicant_data, course)

--- a/src/spz/test/test_signup.py
+++ b/src/spz/test/test_signup.py
@@ -114,14 +114,14 @@ def test_tag_skip(client, applicant_data, course):
 
     assert not in_course(applicant_data, course)
 
-    applicant_data.tag = ''
+    applicant_data['tag'] = ''
     data = dict(applicant_data, course=course.id)
     response = client.post('/', data=data)
     response_text = get_text(response)
     assert "Matrikelnummer muss angegeben werden" in response_text
     assert not in_course(applicant_data, course)
 
-    applicant_data.tag = "Wird nachgereicht"
+    applicant_data['tag'] = "Wird nachgereicht"
     data = dict(applicant_data, course=course.id)
     response = client.post('/', data=data)
     response_text = get_text(response)


### PR DESCRIPTION
Input of matriculation number must be skipped, if (and only if) the student signing up does not know his identification yet.
A new skip-checkbox makes this more obvious to applicants.